### PR TITLE
fixed x64 encoding/decoding, project clean-up, more robust error handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome:
+http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Code files
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+
+# Xml project files
+[*.csproj]
+indent_style = space
+indent_size = 2
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# VS
+.vs

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Roman Belkov, Kirill Melentyev - first version of all files
 Carter Li                      - added conditional compilation (x86/x64)
+Pent Ploompuu                  - fixed x64 encoding/decoding, removed separate x86/x64 build configurations, exposed encoding options with more natural defaults, more robust error handling

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Roman Belkov, Kirill Melentyev - first version of all files
 Carter Li                      - added conditional compilation (x86/x64)
-Pent Ploompuu                  - fixed x64 encoding/decoding, removed separate x86/x64 build configurations, exposed encoding options with more natural defaults, more robust error handling
+Pent Ploompuu                  - fixed x64 encoding/decoding, removed separate x86/x64 build configurations, exposed encoding options with more natural defaults, more robust error handling, drastically reduced memory churn

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,5 @@
 Roman Belkov, Kirill Melentyev - first version of all files
 Carter Li                      - added conditional compilation (x86/x64)
-Pent Ploompuu                  - fixed x64 encoding/decoding, removed separate x86/x64 build configurations, exposed encoding options with more natural defaults, more robust error handling, drastically reduced memory churn
+Pent Ploompuu                  - fixed x64 encoding/decoding, removed separate x86/x64 build configurations,
+                                 exposed encoding options with more natural defaults, more robust error handling,
+                                 drastically reduced memory churn, single-call buffer encoding/decoding

--- a/Examples/App.config
+++ b/Examples/App.config
@@ -2,5 +2,5 @@
 <configuration>
     <startup> 
         
-    <supportedRuntime version="v2.0.50727"/></startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
 </configuration>

--- a/Examples/App.config
+++ b/Examples/App.config
@@ -2,5 +2,5 @@
 <configuration>
     <startup> 
         
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
 </configuration>

--- a/Examples/App.config
+++ b/Examples/App.config
@@ -2,5 +2,5 @@
 <configuration>
     <startup> 
         
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup>
 </configuration>

--- a/Examples/App.config
+++ b/Examples/App.config
@@ -2,5 +2,5 @@
 <configuration>
     <startup> 
         
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
+    <supportedRuntime version="v2.0.50727"/></startup>
 </configuration>

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -9,12 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Examples</RootNamespace>
     <AssemblyName>Examples</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -24,7 +22,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -34,24 +31,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Examples</RootNamespace>
     <AssemblyName>Examples</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -9,7 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Examples</RootNamespace>
     <AssemblyName>Examples</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Examples</RootNamespace>
     <AssemblyName>Examples</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>

--- a/README.md
+++ b/README.md
@@ -11,19 +11,20 @@ This project uses a public domain compression library liblzma from XZ Utils and 
 
 The intentions of this library is to provide basic operations with `.xz` file format to .NET (C#, F#, VB) developers.
 
-*Please note that library is in the early stages of development and many features are missing. Also, bugs may be present. The library was tested with `i686-sse2`  and `x86-64` version of liblzma 5.2.1 (these versions are included in project under names liblzma.dll and liblzma64.dll).*
+*The library was tested with `i686-sse2`  and `x86-64` version of liblzma 5.2.1 (these versions are included in project under names liblzma.dll and liblzma64.dll).*
 
 **You can find some basic examples in 'Examples' folder of project.**
 
 ## ChangeLog ##
 
-13/12/2016 - 2.0.0
+15/12/2016 - 2.0.0
 
 - Fixed x64 encoding/decoding
 - Removed separate x86/x64 build configurations
 - Exposed encoding options with more natural defaults
 - More robust error handling
 - Guard against buffer overflows
+- Drastically reduced memory churn (2x-4x faster depending on workload)
 
 09/09/2015 - 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ The intentions of this library is to provide basic operations with `.xz` file fo
 
 ## ChangeLog ##
 
+13/12/2016 - 2.0.0
+
+- Fixed x64 encoding/decoding
+- Removed separate x86/x64 build configurations
+- Exposed encoding options with more natural defaults
+- More robust error handling
+
 09/09/2015 - 1.2.0
 
 - Compression part of library should work fine from now on

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The intentions of this library is to provide basic operations with `.xz` file fo
 - Removed separate x86/x64 build configurations
 - Exposed encoding options with more natural defaults
 - More robust error handling
+- Guard against buffer overflows
 
 09/09/2015 - 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The intentions of this library is to provide basic operations with `.xz` file fo
 
 ## ChangeLog ##
 
-15/12/2016 - 2.0.0
+20/12/2016 - 2.0.0
 
 - Fixed x64 encoding/decoding
 - Removed separate x86/x64 build configurations
@@ -25,6 +25,7 @@ The intentions of this library is to provide basic operations with `.xz` file fo
 - More robust error handling
 - Guard against buffer overflows
 - Drastically reduced memory churn (2x-4x faster depending on workload)
+- Single-call buffer encoding/decoding functions
 
 09/09/2015 - 1.2.0
 

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -23,6 +23,7 @@
 */
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace XZ.NET
@@ -60,7 +61,6 @@ namespace XZ.NET
         LzmaCheckSha256 = 10
     }
 
-    [StructLayout(LayoutKind.Sequential)]
     internal struct LzmaStreamFlags
     {
         private readonly UInt32 version;
@@ -85,7 +85,6 @@ namespace XZ.NET
         private readonly UInt32 reserved_int2;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
     internal struct LzmaMT
     {
         public UInt32 flags;
@@ -114,7 +113,6 @@ namespace XZ.NET
         private readonly IntPtr reserved_ptr4;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
     internal struct LzmaStream
     {
         public IntPtr next_in;
@@ -140,97 +138,112 @@ namespace XZ.NET
         private readonly UInt32 reserved_enum1;
         private readonly UInt32 reserved_enum2;
     }
+
     static class Native
     {
-        internal delegate LzmaReturn lzma_stream_decoder_delegate(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
-        internal static readonly lzma_stream_decoder_delegate lzma_stream_decoder = IntPtr.Size > 4 ? (lzma_stream_decoder_delegate)NativeX64.lzma_stream_decoder : NativeX86.lzma_stream_decoder;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags)
+            => IntPtr.Size > 4 ? X64.lzma_stream_decoder(ref stream, memLimit, flags) : X86.lzma_stream_decoder(ref stream, memLimit, flags);
 
-        internal delegate LzmaReturn lzma_code_delegate(ref LzmaStream stream, LzmaAction action);
-        internal static readonly lzma_code_delegate lzma_code = IntPtr.Size > 4 ? (lzma_code_delegate)NativeX64.lzma_code : NativeX86.lzma_code;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action) => IntPtr.Size > 4 ? X64.lzma_code(ref stream, action) : X86.lzma_code(ref stream, action);
 
-        internal delegate LzmaReturn lzma_stream_footer_decode_delegate(ref LzmaStreamFlags options, byte[] inp);
-        internal static readonly lzma_stream_footer_decode_delegate lzma_stream_footer_decode = IntPtr.Size > 4 ? (lzma_stream_footer_decode_delegate)NativeX64.lzma_stream_footer_decode : NativeX86.lzma_stream_footer_decode;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp)
+            => IntPtr.Size > 4 ? X64.lzma_stream_footer_decode(ref options, inp) : X86.lzma_stream_footer_decode(ref options, inp);
 
-        internal delegate UInt64 lzma_index_uncompressed_size_delegate(IntPtr i);
-        internal static readonly lzma_index_uncompressed_size_delegate lzma_index_uncompressed_size = IntPtr.Size > 4 ? (lzma_index_uncompressed_size_delegate)NativeX64.lzma_index_uncompressed_size : NativeX86.lzma_index_uncompressed_size;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static UInt64 lzma_index_uncompressed_size(IntPtr i) => IntPtr.Size > 4 ? X64.lzma_index_uncompressed_size(i) : X86.lzma_index_uncompressed_size(i);
 
-        internal delegate UInt32 lzma_index_buffer_decode_delegate(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer, ref UInt32 inPosition, UInt64 inSize);
-        internal static readonly lzma_index_buffer_decode_delegate lzma_index_buffer_decode = IntPtr.Size > 4 ? (lzma_index_buffer_decode_delegate)NativeX64.lzma_index_buffer_decode : NativeX86.lzma_index_buffer_decode;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer, ref UInt32 inPosition, UInt64 inSize)
+            => IntPtr.Size > 4 ? X64.lzma_index_buffer_decode(ref i, ref memLimit, allocator, indexBuffer, ref inPosition, inSize)
+            : X86.lzma_index_buffer_decode(ref i, ref memLimit, allocator, indexBuffer, ref inPosition, inSize);
 
-        internal delegate void lzma_index_end_delegate(IntPtr i, IntPtr allocator);
-        internal static readonly lzma_index_end_delegate lzma_index_end = IntPtr.Size > 4 ? (lzma_index_end_delegate)NativeX64.lzma_index_end : NativeX86.lzma_index_end;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void lzma_index_end(IntPtr i, IntPtr allocator)
+        {
+            if(IntPtr.Size > 4) X64.lzma_index_end(i, allocator);
+            else X86.lzma_index_end(i, allocator);
+        }
 
-        internal delegate void lzma_end_delegate(ref LzmaStream stream);
-        internal static readonly lzma_end_delegate lzma_end = IntPtr.Size > 4 ? (lzma_end_delegate)NativeX64.lzma_end : NativeX86.lzma_end;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void lzma_end(ref LzmaStream stream)
+        {
+            if(IntPtr.Size > 4) X64.lzma_end(ref stream);
+            else X86.lzma_end(ref stream);
+        }
 
-        internal delegate LzmaReturn lzma_stream_encoder_mt_delegate(ref LzmaStream stream, ref LzmaMT mt);
-        internal static readonly lzma_stream_encoder_mt_delegate lzma_stream_encoder_mt = IntPtr.Size > 4 ? (lzma_stream_encoder_mt_delegate)NativeX64.lzma_stream_encoder_mt : NativeX86.lzma_stream_encoder_mt;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt)
+            => IntPtr.Size > 4 ? X64.lzma_stream_encoder_mt(ref stream, ref mt) : X86.lzma_stream_encoder_mt(ref stream, ref mt);
 
-        internal delegate LzmaReturn lzma_easy_encoder_delegate(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
-        internal static readonly lzma_easy_encoder_delegate lzma_easy_encoder = IntPtr.Size > 4 ? (lzma_easy_encoder_delegate)NativeX64.lzma_easy_encoder : NativeX86.lzma_easy_encoder;
-    }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check)
+            => IntPtr.Size > 4 ? X64.lzma_easy_encoder(ref stream, preset, check) : X86.lzma_easy_encoder(ref stream, preset, check);
 
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    static class NativeX64
-    {
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
+        [System.Security.SuppressUnmanagedCodeSecurity]
+        static class X64
+        {
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern UInt64 lzma_index_uncompressed_size(IntPtr i);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern UInt64 lzma_index_uncompressed_size(IntPtr i);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer,
-            ref UInt32 inPosition, UInt64 inSize);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer,
+                ref UInt32 inPosition, UInt64 inSize);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void lzma_index_end(IntPtr i, IntPtr allocator);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern void lzma_index_end(IntPtr i, IntPtr allocator);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void lzma_end(ref LzmaStream stream);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern void lzma_end(ref LzmaStream stream);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
 
-        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
-    }
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
+        }
 
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    static class NativeX86
-    {
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
+        [System.Security.SuppressUnmanagedCodeSecurity]
+        static class X86
+        {
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern UInt64 lzma_index_uncompressed_size(IntPtr i);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern UInt64 lzma_index_uncompressed_size(IntPtr i);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer,
-            ref UInt32 inPosition, UInt64 inSize);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer,
+                ref UInt32 inPosition, UInt64 inSize);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void lzma_index_end(IntPtr i, IntPtr allocator);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern void lzma_index_end(IntPtr i, IntPtr allocator);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void lzma_end(ref LzmaStream stream);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern void lzma_end(ref LzmaStream stream);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
 
-        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
+        }
     }
 }

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -73,14 +73,7 @@ namespace XZ.NET
         private readonly int reserved_enum2;
         private readonly int reserved_enum3;
         private readonly int reserved_enum4;
-        private readonly char reserved_bool1;
-        private readonly char reserved_bool2;
-        private readonly char reserved_bool3;
-        private readonly char reserved_bool4;
-        private readonly char reserved_bool5;
-        private readonly char reserved_bool6;
-        private readonly char reserved_bool7;
-        private readonly char reserved_bool8;
+        private readonly byte reserved_bool1, reserved_bool2, reserved_bool3, reserved_bool4, reserved_bool5, reserved_bool6, reserved_bool7, reserved_bool8;
         private readonly UInt32 reserved_int1;
         private readonly UInt32 reserved_int2;
     }
@@ -139,7 +132,7 @@ namespace XZ.NET
         private readonly UInt32 reserved_enum2;
     }
 
-    static class Native
+    static unsafe class Native
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags)
@@ -149,19 +142,19 @@ namespace XZ.NET
         internal static LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action) => IntPtr.Size > 4 ? X64.lzma_code(ref stream, action) : X86.lzma_code(ref stream, action);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp)
-            => IntPtr.Size > 4 ? X64.lzma_stream_footer_decode(ref options, inp) : X86.lzma_stream_footer_decode(ref options, inp);
+        internal static LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp)
+            => IntPtr.Size > 4 ? X64.lzma_stream_footer_decode(options, inp) : X86.lzma_stream_footer_decode(options, inp);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static UInt64 lzma_index_uncompressed_size(IntPtr i) => IntPtr.Size > 4 ? X64.lzma_index_uncompressed_size(i) : X86.lzma_index_uncompressed_size(i);
+        internal static UInt64 lzma_index_uncompressed_size(void* i) => IntPtr.Size > 4 ? X64.lzma_index_uncompressed_size(i) : X86.lzma_index_uncompressed_size(i);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer, ref UInt32 inPosition, UInt64 inSize)
-            => IntPtr.Size > 4 ? X64.lzma_index_buffer_decode(ref i, ref memLimit, allocator, indexBuffer, ref inPosition, inSize)
-            : X86.lzma_index_buffer_decode(ref i, ref memLimit, allocator, indexBuffer, ref inPosition, inSize);
+        internal static LzmaReturn lzma_index_buffer_decode(void** i, UInt64* memLimit, void* allocator, byte[] indexBuffer, UIntPtr* inPosition, UIntPtr inSize)
+            => IntPtr.Size > 4 ? X64.lzma_index_buffer_decode(i, memLimit, allocator, indexBuffer, inPosition, inSize)
+            : X86.lzma_index_buffer_decode(i, memLimit, allocator, indexBuffer, inPosition, inSize);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void lzma_index_end(IntPtr i, IntPtr allocator)
+        internal static void lzma_index_end(void* i, void* allocator)
         {
             if(IntPtr.Size > 4) X64.lzma_index_end(i, allocator);
             else X86.lzma_index_end(i, allocator);
@@ -192,17 +185,16 @@ namespace XZ.NET
             internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp);
+            internal static extern LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern UInt64 lzma_index_uncompressed_size(IntPtr i);
+            internal static extern UInt64 lzma_index_uncompressed_size(void* i);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer,
-                ref UInt32 inPosition, UInt64 inSize);
+            internal static extern LzmaReturn lzma_index_buffer_decode(void** i, UInt64* memLimit, void* allocator, byte[] indexBuffer, UIntPtr* inPosition, UIntPtr inSize);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern void lzma_index_end(IntPtr i, IntPtr allocator);
+            internal static extern void lzma_index_end(void* i, void* allocator);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void lzma_end(ref LzmaStream stream);
@@ -224,17 +216,16 @@ namespace XZ.NET
             internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern LzmaReturn lzma_stream_footer_decode(ref LzmaStreamFlags options, byte[] inp);
+            internal static extern LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern UInt64 lzma_index_uncompressed_size(IntPtr i);
+            internal static extern UInt64 lzma_index_uncompressed_size(void* i);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern UInt32 lzma_index_buffer_decode(ref IntPtr i, ref UInt64 memLimit, IntPtr allocator, byte[] indexBuffer,
-                ref UInt32 inPosition, UInt64 inSize);
+            internal static extern LzmaReturn lzma_index_buffer_decode(void** i, UInt64* memLimit, void* allocator, byte[] indexBuffer, UIntPtr* inPosition, UIntPtr inSize);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern void lzma_index_end(IntPtr i, IntPtr allocator);
+            internal static extern void lzma_index_end(void* i, void* allocator);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void lzma_end(ref LzmaStream stream);

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -134,44 +134,46 @@ namespace XZ.NET
 
     static unsafe class Native
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        const MethodImplOptions inline = (MethodImplOptions)0x100; // AggressiveInlining is not defined before .NET 4.5
+
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags)
             => IntPtr.Size > 4 ? X64.lzma_stream_decoder(ref stream, memLimit, flags) : X86.lzma_stream_decoder(ref stream, memLimit, flags);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action) => IntPtr.Size > 4 ? X64.lzma_code(ref stream, action) : X86.lzma_code(ref stream, action);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp)
             => IntPtr.Size > 4 ? X64.lzma_stream_footer_decode(options, inp) : X86.lzma_stream_footer_decode(options, inp);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static UInt64 lzma_index_uncompressed_size(void* i) => IntPtr.Size > 4 ? X64.lzma_index_uncompressed_size(i) : X86.lzma_index_uncompressed_size(i);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_index_buffer_decode(void** i, UInt64* memLimit, void* allocator, byte[] indexBuffer, UIntPtr* inPosition, UIntPtr inSize)
             => IntPtr.Size > 4 ? X64.lzma_index_buffer_decode(i, memLimit, allocator, indexBuffer, inPosition, inSize)
             : X86.lzma_index_buffer_decode(i, memLimit, allocator, indexBuffer, inPosition, inSize);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static void lzma_index_end(void* i, void* allocator)
         {
             if(IntPtr.Size > 4) X64.lzma_index_end(i, allocator);
             else X86.lzma_index_end(i, allocator);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static void lzma_end(ref LzmaStream stream)
         {
             if(IntPtr.Size > 4) X64.lzma_end(ref stream);
             else X86.lzma_end(ref stream);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt)
             => IntPtr.Size > 4 ? X64.lzma_stream_encoder_mt(ref stream, ref mt) : X86.lzma_stream_encoder_mt(ref stream, ref mt);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check)
             => IntPtr.Size > 4 ? X64.lzma_easy_encoder(ref stream, preset, check) : X86.lzma_easy_encoder(ref stream, preset, check);
 

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -140,7 +140,7 @@ namespace XZ.NET
         private readonly UInt32 reserved_enum1;
         private readonly UInt32 reserved_enum2;
     }
-    public static class Native
+    static class Native
     {
         internal delegate LzmaReturn lzma_stream_decoder_delegate(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
         internal static readonly lzma_stream_decoder_delegate lzma_stream_decoder = IntPtr.Size > 4 ? (lzma_stream_decoder_delegate)NativeX64.lzma_stream_decoder : NativeX86.lzma_stream_decoder;
@@ -167,7 +167,8 @@ namespace XZ.NET
         internal static readonly lzma_stream_encoder_mt_delegate lzma_stream_encoder_mt = IntPtr.Size > 4 ? (lzma_stream_encoder_mt_delegate)NativeX64.lzma_stream_encoder_mt : NativeX86.lzma_stream_encoder_mt;
     }
 
-    public static class NativeX64
+    [System.Security.SuppressUnmanagedCodeSecurity]
+    static class NativeX64
     {
         [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
@@ -194,7 +195,9 @@ namespace XZ.NET
         [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
     }
-    public static class NativeX86
+
+    [System.Security.SuppressUnmanagedCodeSecurity]
+    static class NativeX86
     {
         [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -144,7 +144,7 @@ namespace XZ.NET
         internal static LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action) => IntPtr.Size > 4 ? X64.lzma_code(ref stream, action) : X86.lzma_code(ref stream, action);
 
         [MethodImpl(inline)]
-        internal static LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp)
+        internal static LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte* inp)
             => IntPtr.Size > 4 ? X64.lzma_stream_footer_decode(options, inp) : X86.lzma_stream_footer_decode(options, inp);
 
         [MethodImpl(inline)]
@@ -187,7 +187,7 @@ namespace XZ.NET
             internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp);
+            internal static extern LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte* inp);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern UInt64 lzma_index_uncompressed_size(void* i);
@@ -218,7 +218,7 @@ namespace XZ.NET
             internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            internal static extern LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte[] inp);
+            internal static extern LzmaReturn lzma_stream_footer_decode(LzmaStreamFlags* options, byte* inp);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern UInt64 lzma_index_uncompressed_size(void* i);

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -165,6 +165,9 @@ namespace XZ.NET
 
         internal delegate LzmaReturn lzma_stream_encoder_mt_delegate(ref LzmaStream stream, ref LzmaMT mt);
         internal static readonly lzma_stream_encoder_mt_delegate lzma_stream_encoder_mt = IntPtr.Size > 4 ? (lzma_stream_encoder_mt_delegate)NativeX64.lzma_stream_encoder_mt : NativeX86.lzma_stream_encoder_mt;
+
+        internal delegate LzmaReturn lzma_easy_encoder_delegate(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
+        internal static readonly lzma_easy_encoder_delegate lzma_easy_encoder = IntPtr.Size > 4 ? (lzma_easy_encoder_delegate)NativeX64.lzma_easy_encoder : NativeX86.lzma_easy_encoder;
     }
 
     [System.Security.SuppressUnmanagedCodeSecurity]
@@ -194,6 +197,9 @@ namespace XZ.NET
 
         [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
+
+        [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
     }
 
     [System.Security.SuppressUnmanagedCodeSecurity]
@@ -223,5 +229,8 @@ namespace XZ.NET
 
         [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         internal static extern LzmaReturn lzma_stream_encoder_mt(ref LzmaStream stream, ref LzmaMT mt);
+
+        [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
     }
 }

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -106,19 +106,19 @@ namespace XZ.NET
         private readonly IntPtr reserved_ptr4;
     }
 
-    internal struct LzmaStream
+    internal unsafe struct LzmaStream
     {
-        public IntPtr next_in;
+        public byte* next_in;
         public UIntPtr avail_in;
         public UInt64 total_in;
 
-        public IntPtr next_out;
+        public byte* next_out;
         public UIntPtr avail_out;
         public UInt64 total_out;
 
         public IntPtr allocator;
 
-        private readonly IntPtr internalState;
+        public IntPtr internalState;
 
         private readonly IntPtr reserved_ptr1;
         private readonly IntPtr reserved_ptr2;

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -141,6 +141,11 @@ namespace XZ.NET
             => IntPtr.Size > 4 ? X64.lzma_stream_decoder(ref stream, memLimit, flags) : X86.lzma_stream_decoder(ref stream, memLimit, flags);
 
         [MethodImpl(inline)]
+        internal static LzmaReturn lzma_stream_buffer_decode(UInt64* memlimit, UInt32 flags, void* allocator, byte[] @in, UIntPtr* in_pos, UIntPtr in_size, byte[] @out, UIntPtr* out_pos, UIntPtr out_size)
+            => IntPtr.Size > 4 ? X64.lzma_stream_buffer_decode(memlimit, flags, allocator, @in, in_pos, in_size, @out, out_pos, out_size)
+            : X86.lzma_stream_buffer_decode(memlimit, flags, allocator, @in, in_pos, in_size, @out, out_pos, out_size);
+
+        [MethodImpl(inline)]
         internal static LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action) => IntPtr.Size > 4 ? X64.lzma_code(ref stream, action) : X86.lzma_code(ref stream, action);
 
         [MethodImpl(inline)]
@@ -184,6 +189,9 @@ namespace XZ.NET
             internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_buffer_decode(UInt64* memlimit, UInt32 flags, void* allocator, byte[] @in, UIntPtr* in_pos, UIntPtr in_size, byte[] @out, UIntPtr* out_pos, UIntPtr out_size);
+
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
@@ -213,6 +221,9 @@ namespace XZ.NET
         {
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern LzmaReturn lzma_stream_decoder(ref LzmaStream stream, UInt64 memLimit, UInt32 flags);
+
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_stream_buffer_decode(UInt64* memlimit, UInt32 flags, void* allocator, byte[] @in, UIntPtr* in_pos, UIntPtr in_size, byte[] @out, UIntPtr* out_pos, UIntPtr out_size);
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern LzmaReturn lzma_code(ref LzmaStream stream, LzmaAction action);

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -118,11 +118,11 @@ namespace XZ.NET
     internal struct LzmaStream
     {
         public IntPtr next_in;
-        public UInt32 avail_in;
+        public UIntPtr avail_in;
         public UInt64 total_in;
 
         public IntPtr next_out;
-        public UInt32 avail_out;
+        public UIntPtr avail_out;
         public UInt64 total_out;
 
         public IntPtr allocator;
@@ -135,8 +135,8 @@ namespace XZ.NET
         private readonly IntPtr reserved_ptr4;
         private readonly UInt64 reserved_int1;
         private readonly UInt64 reserved_int2;
-        private readonly UInt32 reserved_int3;
-        private readonly UInt32 reserved_int4;
+        private readonly UIntPtr reserved_int3;
+        private readonly UIntPtr reserved_int4;
         private readonly UInt32 reserved_enum1;
         private readonly UInt32 reserved_enum2;
     }

--- a/XZ.NET/NativeMethods.cs
+++ b/XZ.NET/NativeMethods.cs
@@ -182,6 +182,15 @@ namespace XZ.NET
         internal static LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check)
             => IntPtr.Size > 4 ? X64.lzma_easy_encoder(ref stream, preset, check) : X86.lzma_easy_encoder(ref stream, preset, check);
 
+        [MethodImpl(inline)]
+        internal static UIntPtr lzma_stream_buffer_bound(UIntPtr uncompressed_size)
+            => IntPtr.Size > 4 ? X64.lzma_stream_buffer_bound(uncompressed_size) : X86.lzma_stream_buffer_bound(uncompressed_size);
+
+        [MethodImpl(inline)]
+        internal static LzmaReturn lzma_easy_buffer_encode(UInt32 preset, LzmaCheck check, void* allocator, byte[] @in, UIntPtr in_size, byte[] @out, UIntPtr* out_pos, UIntPtr out_size)
+            => IntPtr.Size > 4 ? X64.lzma_easy_buffer_encode(preset, check, allocator, @in, in_size, @out, out_pos, out_size)
+            : X86.lzma_easy_buffer_encode(preset, check, allocator, @in, in_size, @out, out_pos, out_size);
+
         [System.Security.SuppressUnmanagedCodeSecurity]
         static class X64
         {
@@ -214,6 +223,12 @@ namespace XZ.NET
 
             [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
+
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern UIntPtr lzma_stream_buffer_bound(UIntPtr uncompressed_size);
+
+            [DllImport("liblzma64.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_easy_buffer_encode(UInt32 preset, LzmaCheck check, void* allocator, byte[] @in, UIntPtr in_size, byte[] @out, UIntPtr* out_pos, UIntPtr out_size);
         }
 
         [System.Security.SuppressUnmanagedCodeSecurity]
@@ -248,6 +263,12 @@ namespace XZ.NET
 
             [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
             internal static extern LzmaReturn lzma_easy_encoder(ref LzmaStream stream, UInt32 preset, LzmaCheck check);
+
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern UIntPtr lzma_stream_buffer_bound(UIntPtr uncompressed_size);
+
+            [DllImport("liblzma.dll", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern LzmaReturn lzma_easy_buffer_encode(UInt32 preset, LzmaCheck check, void* allocator, byte[] @in, UIntPtr in_size, byte[] @out, UIntPtr* out_pos, UIntPtr out_size);
         }
     }
 }

--- a/XZ.NET/Properties/AssemblyInfo.cs
+++ b/XZ.NET/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("XZ.NET")]
 [assembly: AssemblyDescription(".NET wrapper for liblzma (XZ Utils)")]
 [assembly: AssemblyProduct("XZ.NET")]
-[assembly: AssemblyCopyright("© Roman Belkov, Kirill Melentyev, Pent Ploompuu 2016")]
+[assembly: AssemblyCopyright("© Roman Belkov, Kirill Melentyev, Pent Ploompuu 2017")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/XZ.NET/Properties/AssemblyInfo.cs
+++ b/XZ.NET/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -7,30 +6,12 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("XZ.NET")]
 [assembly: AssemblyDescription(".NET wrapper for liblzma (XZ Utils)")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("XZ.NET")]
-[assembly: AssemblyCopyright("Copyright © Roman Belkov & Kirill Melentyev 2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyCopyright("© Roman Belkov, Kirill Melentyev, Pent Ploompuu 2016")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("12343423-cc1d-47ef-a2b6-16043a43150f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]

--- a/XZ.NET/XZ.NET.csproj
+++ b/XZ.NET/XZ.NET.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XZ.NET</RootNamespace>
     <AssemblyName>XZ.NET</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>

--- a/XZ.NET/XZ.NET.csproj
+++ b/XZ.NET/XZ.NET.csproj
@@ -9,7 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XZ.NET</RootNamespace>
     <AssemblyName>XZ.NET</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -26,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/XZ.NET/XZ.NET.csproj
+++ b/XZ.NET/XZ.NET.csproj
@@ -9,9 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XZ.NET</RootNamespace>
     <AssemblyName>XZ.NET</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,34 +21,14 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants></DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/XZ.NET/XZ.NET.csproj
+++ b/XZ.NET/XZ.NET.csproj
@@ -9,10 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>XZ.NET</RootNamespace>
     <AssemblyName>XZ.NET</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XZ.NET/XZ.NET.sln
+++ b/XZ.NET/XZ.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.25920.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XZ.NET", "XZ.NET.csproj", "{2A389B68-70DC-4853-81AE-56484F32E94D}"
 EndProject
@@ -10,27 +10,17 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2A389B68-70DC-4853-81AE-56484F32E94D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2A389B68-70DC-4853-81AE-56484F32E94D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2A389B68-70DC-4853-81AE-56484F32E94D}.Debug|x64.ActiveCfg = Debug|x64
-		{2A389B68-70DC-4853-81AE-56484F32E94D}.Debug|x64.Build.0 = Debug|x64
 		{2A389B68-70DC-4853-81AE-56484F32E94D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A389B68-70DC-4853-81AE-56484F32E94D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2A389B68-70DC-4853-81AE-56484F32E94D}.Release|x64.ActiveCfg = Release|x64
-		{2A389B68-70DC-4853-81AE-56484F32E94D}.Release|x64.Build.0 = Release|x64
 		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Debug|x64.ActiveCfg = Debug|x64
-		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Debug|x64.Build.0 = Debug|x64
 		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Release|x64.ActiveCfg = Release|x64
-		{EBEC5795-82AB-455E-806B-64099BA50A0A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -52,7 +52,7 @@ namespace XZ.NET
 
             var ret = Native.lzma_stream_decoder(ref _lzmaStream, UInt64.MaxValue, LzmaConcatenatedFlag);
 
-            if(ret == LzmaReturn.LzmaOK)
+            if (ret == LzmaReturn.LzmaOK)
             {
                 _inbuf = Marshal.AllocHGlobal(BufSize);
                 _outbuf = Marshal.AllocHGlobal(BufSize);
@@ -248,7 +248,7 @@ namespace XZ.NET
             set { throw new NotSupportedException("XZ Stream does not support setting position"); }
         }
 
-        ~XZInputStream() => Dispose(false);
+        ~XZInputStream() { Dispose(false); }
 
         protected override void Dispose(bool disposing)
         {

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 
 namespace XZ.NET
 {
-    public sealed class XZInputStream : Stream
+    public class XZInputStream : Stream
     {
         private readonly List<byte> _mInternalBuffer = new List<byte>();
         private LzmaStream _lzmaStream;

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -62,6 +62,7 @@ namespace XZ.NET
                 return;
             }
 
+            GC.SuppressFinalize(this);
             switch (ret)
             {
                 case LzmaReturn.LzmaMemError:
@@ -106,7 +107,8 @@ namespace XZ.NET
             {
                 if (_lzmaStream.avail_in == UIntPtr.Zero)
                 {
-                    _lzmaStream.avail_in = (UIntPtr)checked((uint)_mInnerStream.Read(readBuf, 0, readBuf.Length));
+                    _lzmaStream.avail_in = (UIntPtr)_mInnerStream.Read(readBuf, 0, readBuf.Length);
+                    if((uint)_lzmaStream.avail_in > BufSize) throw new InvalidOperationException();
                     Marshal.Copy(readBuf, 0, _inbuf, (int)_lzmaStream.avail_in);
                     _lzmaStream.next_in = _inbuf;
 
@@ -251,10 +253,7 @@ namespace XZ.NET
             set { throw new NotSupportedException("XZ Stream does not support setting position"); }
         }
 
-        public override void Close()
-        {
-            Dispose(true);
-        }
+        ~XZInputStream() => Dispose(false);
 
         protected override void Dispose(bool disposing)
         {

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -155,7 +155,7 @@ namespace XZ.NET
                             throw new InvalidDataException("Compressed file is truncated or otherwise corrupt");
 
                         default:
-                            throw new Exception("Uknown error.Possibly a bug");
+                            throw new Exception("Unknown error, possibly a bug: " + ret);
                     }
                 }
             }

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 
 namespace XZ.NET
 {
-    public class XZInputStream : Stream
+    public sealed class XZInputStream : Stream
     {
         private readonly List<byte> _mInternalBuffer = new List<byte>();
         private LzmaStream _lzmaStream;

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -62,7 +62,7 @@ namespace XZ.NET
             switch (ret)
             {
                 case LzmaReturn.LzmaMemError:
-                    throw new Exception("Memory allocation failed");
+                    throw new InsufficientMemoryException("Memory allocation failed");
 
                 case LzmaReturn.LzmaOptionsError:
                     throw new Exception("Unsupported decompressor flags");
@@ -136,19 +136,19 @@ namespace XZ.NET
                     switch (ret)
                     {
                         case LzmaReturn.LzmaMemError:
-                            throw new Exception("Memory allocation failed");
+                            throw new InsufficientMemoryException("Memory allocation failed");
 
                         case LzmaReturn.LzmaFormatError:
-                            throw new Exception("The input is not in the .xz format");
+                            throw new InvalidDataException("The input is not in the .xz format");
 
                         case LzmaReturn.LzmaOptionsError:
                             throw new Exception("Unsupported compression options");
 
                         case LzmaReturn.LzmaDataError:
-                            throw new Exception("Compressed file is corrupt");
+                            throw new InvalidDataException("Compressed file is corrupt");
 
                         case LzmaReturn.LzmaBufError:
-                            throw new Exception("Compressed file is truncated or otherwise corrupt");
+                            throw new InvalidDataException("Compressed file is truncated or otherwise corrupt");
 
                         default:
                             throw new Exception("Uknown error.Possibly a bug");
@@ -226,7 +226,7 @@ namespace XZ.NET
                     if (inPos != lzmaStreamFlags.backwardSize)
                     {
                         Native.lzma_index_end(index, IntPtr.Zero);
-                        throw new Exception("Index decoding failed!");
+                        throw new InvalidDataException("Index decoding failed!");
                     }
 
                     var uSize = Native.lzma_index_uncompressed_size(index);

--- a/XZ.NET/XZInputStream.cs
+++ b/XZ.NET/XZInputStream.cs
@@ -64,17 +64,7 @@ namespace XZ.NET
                 return;
 
             GC.SuppressFinalize(this);
-            switch (ret)
-            {
-                case LzmaReturn.LzmaMemError:
-                    throw new InsufficientMemoryException("Memory allocation failed");
-
-                case LzmaReturn.LzmaOptionsError:
-                    throw new Exception("Unsupported decompressor flags");
-
-                default:
-                    throw new Exception("Unknown error, possibly a bug");
-            }
+            throw GetDecodingError(ret);
         }
 
         #region Overrides

--- a/XZ.NET/XZOutputStream.cs
+++ b/XZ.NET/XZOutputStream.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 
 namespace XZ.NET
 {
-    public sealed class XZOutputStream : Stream
+    public class XZOutputStream : Stream
     {
         private LzmaStream _lzmaStream;
         private readonly Stream _mInnerStream;

--- a/XZ.NET/XZOutputStream.cs
+++ b/XZ.NET/XZOutputStream.cs
@@ -89,7 +89,7 @@ namespace XZ.NET
             switch (ret)
             {
                 case LzmaReturn.LzmaMemError:
-                    throw new Exception("Memory allocation failed");
+                    throw new InsufficientMemoryException("Memory allocation failed");
 
                 case LzmaReturn.LzmaOptionsError:
                     throw new Exception("Specified preset is not supported");
@@ -131,7 +131,7 @@ namespace XZ.NET
             if (_lzmaStream.avail_in == 0)
             {
                 _lzmaStream.avail_in = (uint)count;
-                Marshal.Copy(buffer, 0, _inbuf, (int)_lzmaStream.avail_in);
+                Marshal.Copy(buffer, offset, _inbuf, (int)_lzmaStream.avail_in);
                 _lzmaStream.next_in = _inbuf;
 
                 if (count < BufSize)
@@ -185,7 +185,7 @@ namespace XZ.NET
                 switch (ret)
                 {
                     case LzmaReturn.LzmaMemError:
-                        throw new Exception("Memory allocation failed");
+                        throw new InsufficientMemoryException("Memory allocation failed");
 
                     case LzmaReturn.LzmaDataError:
                         throw new Exception("File size limits exceeded");

--- a/XZ.NET/XZOutputStream.cs
+++ b/XZ.NET/XZOutputStream.cs
@@ -60,7 +60,7 @@ namespace XZ.NET
             else
             {
                 if(threads <= 0) throw new ArgumentOutOfRangeException(nameof(threads));
-                if(threads > Environment.ProcessorCount)
+                if (threads > Environment.ProcessorCount)
                 {
                     Trace.TraceWarning("{0} threads required, but only {1} processors available", threads, Environment.ProcessorCount);
                     threads = Environment.ProcessorCount;
@@ -74,7 +74,7 @@ namespace XZ.NET
                 ret = Native.lzma_stream_encoder_mt(ref _lzmaStream, ref mt);
             }
 
-            if(ret == LzmaReturn.LzmaOK)
+            if (ret == LzmaReturn.LzmaOK)
             {
                 _inbuf = Marshal.AllocHGlobal(BufSize);
                 _outbuf = Marshal.AllocHGlobal(BufSize);
@@ -211,7 +211,7 @@ namespace XZ.NET
             base.Close();
         }
 
-        ~XZOutputStream() => Dispose(false);
+        ~XZOutputStream() { Dispose(false); }
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
- Fixed x64 encoding/decoding
- Removed separate x86/x64 build configurations
- Exposed encoding options with more natural defaults
- More robust error handling
- Guard against buffer overflows